### PR TITLE
Added a check in the culling code to skip unaligned queries

### DIFF
--- a/famli/famli_helpers.py
+++ b/famli/famli_helpers.py
@@ -275,6 +275,9 @@ class FAMLI_Reassignment:
         newly_unique_queries = set([])
         for query in self.multimapped_queries:
             aln_prob = self.aln_prob[query]
+            # Skip queries with no remaining alignments
+            if len(aln_prob) == 0:
+                continue
             # Skip queries with only a single possible subject
             if len(aln_prob) == 1:
                 newly_unique_queries.add(query)


### PR DESCRIPTION
Caused a bug when calculating percentiles. Can speed up the for loop a drop. 